### PR TITLE
Added additional info to the warning about a PIPX_HOME dir with spaces

### DIFF
--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -154,6 +154,22 @@ class _PathContext:
                     subsequent_indent=" " * 4,
                 )
             )
+            logger.warning(
+                pipx_wrap(
+                    (
+                        f"{hazard} To see your PIPX_HOME dir: pipx environment --value PIPX_HOME"
+                    ),
+                    subsequent_indent=" " * 4,
+                )
+            )
+            logger.warning(
+                pipx_wrap(
+                    (
+                        f"{hazard} Most likely fix on macOS: mv ~/Library/Application\\ Support/pipx ~/.local/"
+                    ),
+                    subsequent_indent=" " * 4,
+                )
+            )
 
         fallback_home_exists = self._fallback_home is not None and self._fallback_home.exists()
         specific_home_exists = self.home != self._fallback_home


### PR DESCRIPTION
The current warning is very generic and requires the user to go hunting through docs to figure out a solution.  Adding a little extra information in the warning logs will allow for quicker resolution.

<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
